### PR TITLE
Update CI configuration for pull requests only

### DIFF
--- a/.github/workflows/test-pass.yml
+++ b/.github/workflows/test-pass.yml
@@ -1,8 +1,6 @@
 name: Node.js test CI
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
 
@@ -11,16 +9,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [22.x]
-
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 22.x
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 22.x
         cache: 'npm'
     - name: Install dependencies
       run: npm install


### PR DESCRIPTION
Modify the CI configuration to trigger actions only on pull requests to the main branch and simplify the Node.js version setup.